### PR TITLE
Added unmapped languages

### DIFF
--- a/ASFAchievementManager/AchievementHandler.cs
+++ b/ASFAchievementManager/AchievementHandler.cs
@@ -95,15 +95,33 @@ namespace ASFAchievementManager {
 									string? dependancyName = (Achievement.Children.Find(Child => Child.Name == "progress") == null) ? "" : Achievement.Children.Find(Child => Child.Name == "progress")?.Children?.Find(Child => Child.Name == "value")?.Children?.Find(Child => Child.Name == "operand1")?.Value;
 
 									uint.TryParse((Achievement.Children.Find(Child => Child.Name == "progress") == null) ? "0" : Achievement.Children.Find(Child => Child.Name == "progress")!.Children.Find(Child => Child.Name == "max_val")?.Value, out uint dependancyValue);
-									string lang = CultureInfo.CurrentUICulture.EnglishName.ToLower();
-									if (lang.IndexOf('(') > 0) {
-										lang = lang.Substring(0, lang.IndexOf('(') - 1);
-									}
-									if (Achievement.Children.Find(Child => Child.Name == "display")?.Children?.Find(Child => Child.Name == "name")?.Children?.Find(Child => Child.Name == lang) == null) {
-										lang = "english";//fallback to english
-									}
+                                    string lang = CultureInfo.CurrentUICulture.EnglishName.ToLower();
 
-									string? name = Achievement.Children.Find(Child => Child.Name == "display")?.Children?.Find(Child => Child.Name == "name")?.Children?.Find(Child => Child.Name == lang)?.Value;
+                                    Dictionary<string, string> countryLanguageMap = new()
+                                    {
+                                            { "portuguese (brazil)", "brazilian" },
+                                            { "korean", "koreana" },
+                                            { "chinese (traditional)", "tchinese" },
+                                            { "chinese (simplified)", "schinese" }
+                                    };
+
+                                    if (countryLanguageMap.ContainsKey(lang))
+                                    {
+                                        lang = countryLanguageMap[lang];
+                                    }
+                                    else
+                                    {
+                                        if (lang.IndexOf('(') > 0)
+                                        {
+                                            lang = lang.Substring(0, lang.IndexOf('(') - 1);
+                                        }
+                                    }
+                                    if (Achievement.Children.Find(Child => Child.Name == "display")?.Children?.Find(Child => Child.Name == "name")?.Children?.Find(Child => Child.Name == lang) == null)
+                                    {
+                                        lang = "english"; // Fallback
+                                    }
+
+                                    string? name = Achievement.Children.Find(Child => Child.Name == "display")?.Children?.Find(Child => Child.Name == "name")?.Children?.Find(Child => Child.Name == lang)?.Value;
 									result.Add(new StatData() {
 										StatNum = statNum,
 										BitNum = bitNum,


### PR DESCRIPTION
Steam doesn't use the same culture language string for some supported countries, causing the plugin to fallback to English.

A practical example of this is the Brazilian Portuguese language. Almost all games that have localized achievements translate them into ``pt-BR`` rather than ``pt-PT``. This results in the plugin retrieving achievements only in english, as games with achievements in Portuguese (Portugal) are very (very) rare.

In my solution, which is actually simple, I created a function that checks if the machine's language is one of the countries where this problem occurs, and then corrects it to the correct 'lang' that exists on Steam.